### PR TITLE
fix: Added jq based output string encoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM docker.io/alpine:latest
 
 COPY entrypoint.sh /entrypoint.sh
-RUN apk add --no-cache git && \
+RUN apk add --no-cache git jq && \
     wget -O /usr/local/bin/git-chglog \
-        https://github.com/git-chglog/git-chglog/releases/download/0.9.1/git-chglog_linux_amd64 && \
+    https://github.com/git-chglog/git-chglog/releases/download/0.9.1/git-chglog_linux_amd64 && \
     chmod 755 /entrypoint.sh /usr/local/bin/git-chglog
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,12 +47,7 @@ if [ -f "${config}/config.yml" ] && [ -f "${config}/CHANGELOG.tpl.md" ]; then
     echo "${changelog}" > ${output}
   fi
 
-  changelog="${changelog//'%'/'%25'}"
-  changelog="${changelog//$'\n'/'%0A'}"
-  changelog="${changelog//$'\r'/'%0D'}"
-  echo "::set-output name=changelog::${changelog}"
-
-
+  echo "::set-output name=changelog::$( jq -sRr @uri <<<$changelog )"
 
 else 
   echo "::warning ::git-chlog configuration was not found, skipping changelog generation."


### PR DESCRIPTION
Fixed segfault issue caused by bad output variable escaping. Now using the `jq` tool to ensure proper escaping.
<!-- 
Pull requests must conform to the Conventional commit sepecification

Read more here: https://www.conventionalcommits.org/en/v1.0.0/

Title format: 
<type>[optional scope]: <description>


Body format:
[optional body]

[optional footer(s)]

----------------------------------------------------------------------------

Example: 

type(scope): description

BREAKING CHANGE: Describe breaking change in footer
-->
